### PR TITLE
Update utils.dart which removes below mentioned error

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -6,7 +6,8 @@ class Utils {
   static Future capture(GlobalKey key) async {
     if (key == null) return null;
 
-    RenderRepaintBoundary boundary = key.currentContext.findRenderObject();
+    RenderRepaintBoundary boundary =
+          key.currentContext!.findRenderObject() as RenderRepaintBoundary;
     final image = await boundary.toImage(pixelRatio: 3);
     final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
     final pngBytes = byteData.buffer.asUint8List();


### PR DESCRIPTION
A value of type 'RenderObject?' can't be assigned to a variable of type 'RenderRepaintBoundary